### PR TITLE
Fix: Makefile docker compose command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,21 @@ benchmark-insert: # Run insert benchmarks
 	go run main.go -operation insert
 
 benchmark-insert-bulk: # Run insert bulk benchmarks
-	docker-compose up -d --no-recreate
+	docker compose up -d --no-recreate
 	go run main.go -operation insert-bulk
 
 benchmark-update: # Run update benchmarks
-	docker-compose up -d --no-recreate
+	docker compose up -d --no-recreate
 	go run main.go -operation update
 
 benchmark-delete: # Run delete benchmarks
-	docker-compose up -d --no-recreate
+	docker compose up -d --no-recreate
 	go run main.go -operation delete
 
 benchmark-select-one: # Run select one benchmarks
-	docker-compose up -d --no-recreate
+	docker compose up -d --no-recreate
 	go run main.go -operation select-one
 
 benchmark-select-page: # Run select page benchmarks
-	docker-compose up -d --no-recreate
+	docker compose up -d --no-recreate
 	go run main.go -operation select-page


### PR DESCRIPTION
Remove "-" character from "docker compose" command, as describe in the docker compose docs (https://docs.docker.com/reference/cli/docker/compose/) the "docker compose" command don't have the character "-" between "docker" and "compose" 

When running these make commands 
`make benchmark-insert-bulk`
`make benchmark-update`
`make benchmark-delete`
`make benchmark-select-one`
`make benchmark-select-page`
is returned a Error 127
```
docker-compose up -d --no-recreate
make: docker-compose: No such file or directory
make: *** [Makefile:10: benchmark-insert-bulk] Error 127
```